### PR TITLE
Update for Rails 4

### DIFF
--- a/google_analytics_mailer.gemspec
+++ b/google_analytics_mailer.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   # gem dependencies for runtime
   gem.add_runtime_dependency "addressable", "~> 2.3.0"
-  gem.add_runtime_dependency "actionmailer", "~> 3.2.0"
+  gem.add_runtime_dependency "actionmailer", ">= 3.2.0"
 
   # gem dependencies for development
   gem.add_development_dependency "rake"


### PR DESCRIPTION
Change the version constraint on action mailer to allow the gem to
bundle with Rails 4. Tests pass with ActionMailer 4.0.0
