### PR TITLE
Adding optional filter to google_analytics_mailer

### DIFF
--- a/lib/google_analytics_mailer.rb
+++ b/lib/google_analytics_mailer.rb
@@ -9,7 +9,7 @@ require 'active_support/concern'
 module GoogleAnalyticsMailer
 
   # These are the currently GA allowed get params for link tagging
-  VALID_ANALYTICS_PARAMS = [:utm_source, :utm_medium, :utm_campaign, :utm_term, :utm_content]
+  VALID_ANALYTICS_PARAMS = [:utm_source, :utm_medium, :utm_campaign, :utm_term, :utm_content, :filter]
 
   # Enable google analytics link tagging for the mailer (or controller) which call this method
   #
@@ -24,12 +24,14 @@ module GoogleAnalyticsMailer
       raise ArgumentError, "Invalid parameters keys #{params.keys - VALID_ANALYTICS_PARAMS}"
     end
 
+    filter = params.delete(:filter)
+
     # add accessor for class level parameters
     cattr_accessor(:google_analytics_class_params) { params }
+    cattr_accessor(:google_analytics_filter) { filter }
 
     # include the module which provides the actual functionality
     include GoogleAnalytics
-
   end
 
   # Allow usage also in controllers since they have the same structure of ActionMailer

--- a/lib/google_analytics_mailer/uri_builder.rb
+++ b/lib/google_analytics_mailer/uri_builder.rb
@@ -2,6 +2,9 @@ require 'addressable/uri'
 
 # Class used to do the actual insertion of parameters
 class GoogleAnalyticsMailer::UriBuilder
+  def initialize(filter=nil)
+    @filter = filter
+  end
 
   # Append google analytics params to the given uri
   # @param [String] uri the original uri
@@ -17,9 +20,11 @@ class GoogleAnalyticsMailer::UriBuilder
     # if no params return untouched url
     return uri if params.empty?
     # build the final url
-    ::Addressable::URI.parse(uri).tap do |parsed|
-      parsed.query_values = (parsed.query_values || {}).reverse_merge(params) if parsed.absolute?
-    end.to_s.html_safe
+    parsed = ::Addressable::URI.parse(uri)
+    return uri if @filter && !@filter.call(parsed)
+
+    parsed.query_values = (parsed.query_values || {}).reverse_merge(params) if parsed.absolute?
+    parsed.to_s.html_safe
   end
 
 end

--- a/lib/google_analytics_mailer/url_for.rb
+++ b/lib/google_analytics_mailer/url_for.rb
@@ -74,7 +74,7 @@ module GoogleAnalyticsMailer # :nodoc:
     # Return a UriBuilder instance
     # @return [UriBuilder]
     def builder
-      @_builder ||= UriBuilder.new
+      @_builder ||= UriBuilder.new controller.class.google_analytics_filter
     end
 
   end

--- a/spec/helpers/url_for_spec.rb
+++ b/spec/helpers/url_for_spec.rb
@@ -4,6 +4,7 @@ describe GoogleAnalyticsMailer::UrlFor do
 
   before(:each) do
     controller.stub(computed_analytics_params: {utm_source: 'foo'})
+    controller.class.stub(google_analytics_filter: nil)
   end
 
   describe '#with_google_analytics_params' do

--- a/spec/lib/uri_builder_spec.rb
+++ b/spec/lib/uri_builder_spec.rb
@@ -20,6 +20,18 @@ describe GoogleAnalyticsMailer::UriBuilder do
       subject.build('http://www.example.com', {}).should == 'http://www.example.com'
     end
 
+    context 'with a filter' do
+      subject { GoogleAnalyticsMailer::UriBuilder.new ->(uri) { uri.host == 'www.example.com' } }
+
+      it 'should add GA parameters to URIs that match the filter' do
+        subject.build('http://www.example.com', utm_campaign: 'Foo Bar').should include 'utm_campaign=Foo%20Bar'
+      end
+
+      it 'should not add GA parameters to URIs that do not match the filter' do
+        subject.build('http://www.external.com', utm_campaign: 'Foo Bar').should_not include 'utm_campaign=Foo%20Bar'
+      end
+    end
+
   end
 
 end

--- a/spec/support/views/filtered_mailer/welcome.html.erb
+++ b/spec/support/views/filtered_mailer/welcome.html.erb
@@ -1,0 +1,9 @@
+<h1>Newsletter title</h1>
+<div class="body">
+  <!-- this will produce ?utm_medium=email&utm_source=newsletter because of class default params -->
+  <%= link_to('Read online', newsletter_url) %>
+  <!-- local parameters are not overridden, so this produces ?utm_medium=email&utm_source=my_newsletter -->
+  <%= link_to('Read online', newsletter_url(utm_source: 'my_newsletter')) %>
+  <!-- this will get filtered -->
+  <%= link_to('External link', 'http://www.external.com/') %>
+</div>


### PR DESCRIPTION
The original implementation modifies all URIs, including links with non-http schemes and links to external sites.  This pull request allows the user to define a filter, and only URIs matching that filter will be modified.  For example:

```ruby
class MyMailer < ActionMailer::Base
  google_analytics_mailer utm_source: 'newsletter',
                          utm_medium: 'email',
                          filter: ->(uri) { 
                            uri.scheme =~ /\Ahttps?\z/ &&
                            uri.host == 'www.mycompany.com'
                          }
  ...
end
```
